### PR TITLE
Fix to GetServices method on SmDependencyResolver

### DIFF
--- a/content/DependencyResolution/SmDependencyResolver.cs.pp
+++ b/content/DependencyResolution/SmDependencyResolver.cs.pp
@@ -28,7 +28,7 @@ namespace $rootnamespace$
         }
 
         public IEnumerable<object> GetServices(Type serviceType) {
-            return _container.GetAllInstances<object>().Where(s => s.GetType() == serviceType);
+            return _container.GetAllInstances(serviceType).Cast<object>();
         }
     }
 }


### PR DESCRIPTION
The GetServices method wasn't properly getting the instances from the container. I noticed that because it was not properly resolving the implementations of the IModelBinderProvider interface. 
